### PR TITLE
Make usable from Scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,6 @@ libraryDependencies ++= (
 )
 
 libraryDependencies ++= Seq(
-  "com.kifi" %% "json-annotation" % "0.1" % Test,
-  "com.typesafe.play" %% "play-json" % "2.3.8" % Test,
   "org.scalatest" %% "scalatest" % "2.2.4" % Test
 )
 

--- a/src/main/scala/com/github/pathikrit/MetaRest.scala
+++ b/src/main/scala/com/github/pathikrit/MetaRest.scala
@@ -32,10 +32,6 @@ object MetaRest {
           case (q"new $annotation", f) if Set("get", "post", "put") contains annotation.toString => annotation.toString -> f.duplicate
         }
       }
-      newFields.groupBy(_._1) map { case (annotation, values) =>
-        val (className, classFields) = (macros.toTypeName(c)(annotation.capitalize), values.map(_._2))
-        q"@com.kifi.macros.json case class $className(..$classFields)" //TODO: Switch back to jsonstrict once this is fixed: https://github.com/kifi/json-annotation/issues/7
-      }
     }
 
     def modifiedDeclaration(classDecl: ClassDef, compDeclOpt: Option[ModuleDef] = None) = {

--- a/src/test/scala/com/github/pathikrit/suites/MetaRestSuite.scala
+++ b/src/test/scala/com/github/pathikrit/suites/MetaRestSuite.scala
@@ -4,24 +4,6 @@ import org.scalatest._, Matchers._
 
 class MetaRestSuite extends FunSuite {
   import com.github.pathikrit.MetaRest, MetaRest._
-  import play.api.libs.json.{Json, Reads, Writes}
-
-  def testJsonRoundTrip[A: Reads : Writes](model: A) = Json.parse(Json.toJson(model).toString()).as[A] shouldEqual model
-
-  test("Generation of Get, Post, Patch, Put models with JSON capabilities") {
-    @MetaRest case class User(
-      @get                id            : Int,
-      @get @post @patch   name          : String,
-      @get @post          email         : String,
-                          registeredOn  : Long
-    )
-
-    testJsonRoundTrip(User.Get(id = 0, name = "Rick", email = "awesome@msn.com"))
-    testJsonRoundTrip(User.Post(name = "Rick", email = "awesome@msn.com"))
-    "User.Put()" shouldNot compile
-    testJsonRoundTrip(User.Patch(name = Some("Pathikrit")))
-    "User.Patch()" should compile
-  }
 
   test("Non case classes") {
     "@MetaRest class A" shouldNot compile


### PR DESCRIPTION
I want to share my models between the server and client. In this case via Scala.js. This commit removes json-annotation support.  using json-annotation means a dependency on spray-json which isn't scala.js compatible.  I really like the utility of these macros but it pains me to not be able to use them because of an extension that doesn't actually seem needed.
